### PR TITLE
Improve chart rendering and spacing

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -28,7 +28,7 @@
 }
 
 .card--kpi {
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 
 .card--form {
@@ -184,7 +184,7 @@
 /* Chart Container */
 .chart-container {
   position: relative;
-  height: 300px;
+  height: 320px;
   width: 100%;
 }
 

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -52,7 +52,7 @@
 .view__content {
   max-width: 1200px;
   margin: 0 auto;
-  padding: var(--space-6) var(--space-4);
+  padding: var(--space-6);
 }
 
 /* Navigation Tabs */
@@ -119,7 +119,7 @@
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-4);
+  gap: var(--space-6);
 }
 
 /* Planner Layout */

--- a/assets/js/charts.js
+++ b/assets/js/charts.js
@@ -21,7 +21,7 @@ window.StudyGraphCharts = {
 
     // Show placeholder when no data
     const hasData =
-      config?.data?.datasets?.some((ds) => Array.isArray(ds.data) && ds.data.some((v) => v))
+      config?.data?.datasets?.some((ds) => Array.isArray(ds.data) && ds.data.length > 0)
     if (!hasData) {
       const placeholder = document.createElement("div")
       placeholder.className = "chart-placeholder"
@@ -136,10 +136,6 @@ window.StudyGraphCharts = {
   createSubjectPieChart(canvasId, days = 30) {
     const subjectStats = this.StudyGraphStore.getSubjectStats(days)
     const subjects = Object.keys(subjectStats)
-
-    if (subjects.length === 0) {
-      return null
-    }
 
     const colors = [
       "rgba(106, 163, 255, 0.8)",

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="assets/css/theme-dark.css" id="theme-stylesheet">
     
     <!-- Vendor Libraries -->
-    <script defer src="assets/vendor/chart.umd.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script defer src="assets/vendor/idb-keyval-iife.min.js"></script>
     
     <!-- App Scripts -->


### PR DESCRIPTION
## Summary
- load Chart.js from CDN for reliable graph display
- expand layout and form spacing for clearer UI
- adjust chart utilities to show placeholders only when datasets are empty

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6abfa9d50832c9470f225f95e865e