### PR TITLE
feat: improve chart rendering and add countdown

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -182,11 +182,9 @@
 }
 
 /* Chart Container */
-.chart-container {
-  position: relative;
-  height: 320px;
-  width: 100%;
-}
+.chart-container { position: relative; width: 100%; height: 320px }
+@media (max-width: 768px) { .chart-container { height: 260px } }
+@media (min-width: 1024px) { .chart-container { height: 360px } }
 
 .chart-placeholder,
 .chart-error {
@@ -579,3 +577,10 @@
 .chip__remove:hover {
   color: var(--text);
 }
+
+.chart-legend { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px }
+.chart-legend__item { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted, #64748b) }
+.chart-legend__dot { width: 10px; height: 10px; border-radius: 50% }
+
+.gauge-wrap { display: grid; place-items: center; height: 220px }
+.gauge-label { margin-top: 8px; font-size: 12px; color: var(--muted, #64748b) }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,6 +29,14 @@ window.StudyGraphApp = {
       const accent = window.StudyGraphStore.state.prefs.accent
       document.documentElement.style.setProperty("--primary", accent)
 
+      const el = document.getElementById("countdown-days")
+      if (el) {
+        const target = new Date("2026-01-17T00:00:00+09:00")
+        const now = new Date()
+        const diff = Math.ceil((target - new Date(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000)
+        el.textContent = diff > 0 ? diff : 0
+      }
+
       console.log("StudyGraph V2 initialized successfully")
     } catch (error) {
       console.error("Failed to initialize StudyGraph V2:", error)

--- a/assets/js/charts.js
+++ b/assets/js/charts.js
@@ -1,27 +1,46 @@
-// Chart utilities using Chart.js
 window.StudyGraphCharts = {
   charts: {},
-  StudyGraphStore: window.StudyGraphStore, // Declare StudyGraphStore
-  StudyGraphUtils: window.StudyGraphUtils, // Declare StudyGraphUtils
+  StudyGraphStore: window.StudyGraphStore,
+  StudyGraphUtils: window.StudyGraphUtils,
 
-  // Initialize chart
+  palette: ["#6AA3FF","#8B5CF6","#22C55E","#F59E0B","#EF4444","#A855F7","#3B82F6","#10B981","#F97316","#E11D48","#14B8A6","#4F46E5"],
+
+  ensureChart() {
+    return typeof window.Chart !== "undefined"
+  },
+
+  centerTextPlugin: {
+    id: "centerText",
+    afterDraw(chart) {
+      const opts = chart.config.options
+      if (!opts || !opts.plugins || !opts.plugins.centerText) return
+      const ctx = chart.ctx
+      const t1 = opts.plugins.centerText.value || ""
+      const t2 = opts.plugins.centerText.label || ""
+      const w = chart.width, h = chart.height
+      ctx.save()
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillStyle = opts.plugins.centerText.color || "#111827"
+      ctx.font = "600 28px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial"
+      ctx.fillText(t1, w / 2, h / 2 - 6)
+      ctx.font = "400 12px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial"
+      ctx.fillText(t2, w / 2, h / 2 + 14)
+      ctx.restore()
+    }
+  },
+
   createChart(canvasId, config) {
     const canvas = document.getElementById(canvasId)
     if (!canvas) return null
-
-    // Ensure Chart.js is available
-    if (typeof window.Chart === "undefined") {
-      console.error("Chart.js is not loaded")
+    if (!this.ensureChart()) {
       const placeholder = document.createElement("div")
       placeholder.className = "chart-error"
       placeholder.textContent = "グラフを表示できません"
       canvas.replaceWith(placeholder)
       return null
     }
-
-    // Show placeholder when no data
-    const hasData =
-      config?.data?.datasets?.some((ds) => Array.isArray(ds.data) && ds.data.length > 0)
+    const hasData = config && config.data && Array.isArray(config.data.datasets) && config.data.datasets.some(ds => Array.isArray(ds.data))
     if (!hasData) {
       const placeholder = document.createElement("div")
       placeholder.className = "chart-placeholder"
@@ -29,218 +48,206 @@ window.StudyGraphCharts = {
       canvas.replaceWith(placeholder)
       return null
     }
-
-    // Destroy existing chart
-    if (this.charts[canvasId]) {
-      this.charts[canvasId].destroy()
-    }
-
-    // Create new chart
     const ctx = canvas.getContext("2d")
+    const base = window.Chart.defaults
+    base.font.family = "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial"
+    base.color = getComputedStyle(document.documentElement).color || "#e5e7eb"
+    base.plugins.legend.labels.boxWidth = 12
+    base.plugins.legend.labels.boxHeight = 12
+    base.plugins.tooltip.intersect = false
+    base.plugins.tooltip.mode = "index"
+    if (!config.options) config.options = {}
+    if (!config.options.plugins) config.options.plugins = {}
+    if (!config.options.plugins.legend) config.options.plugins.legend = { position: "bottom" }
+    if (!config.options.scales) config.options.scales = {}
+    if (config.options.scales.x) {
+      if (!config.options.scales.x.grid) config.options.scales.x.grid = {}
+      config.options.scales.x.grid.color = "rgba(148,163,184,.3)"
+      if (!config.options.scales.x.ticks) config.options.scales.x.ticks = {}
+      config.options.scales.x.ticks.maxRotation = 0
+    }
+    if (config.options.scales.y) {
+      if (!config.options.scales.y.grid) config.options.scales.y.grid = {}
+      config.options.scales.y.grid.color = "rgba(148,163,184,.3)"
+      if (!config.options.scales.y.ticks) config.options.scales.y.ticks = {}
+      config.options.scales.y.ticks.callback = v => v
+    }
+    config.plugins = Array.isArray(config.plugins) ? config.plugins.concat([this.centerTextPlugin]) : [this.centerTextPlugin]
+    if (this.charts[canvasId]) this.charts[canvasId].destroy()
     this.charts[canvasId] = new window.Chart(ctx, config)
     return this.charts[canvasId]
   },
 
-  // Daily achievement rate chart
-  createDailyRateChart(canvasId, days = 7) {
-    const dailyStats = this.StudyGraphStore.getDailyStats(days)
-
-    const config = {
-      type: "bar",
-      data: {
-        labels: dailyStats.map((stat) => this.StudyGraphUtils.formatDate(new Date(stat.date), "MM/DD")),
-        datasets: [
-          {
-            label: "達成率",
-            data: dailyStats.map((stat) => stat.achievementRate),
-            backgroundColor: "rgba(106, 163, 255, 0.8)",
-            borderColor: "rgba(106, 163, 255, 1)",
-            borderWidth: 1,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            display: false,
-          },
-        },
-        scales: {
-          y: {
-            beginAtZero: true,
-            max: 150,
-            ticks: {
-              callback: (value) => value + "%",
-            },
-          },
-        },
-      },
+  createWeeklyStackedTimeChart(canvasId, days) {
+    const range = this.StudyGraphUtils.getDateRange(days)
+    const labels = []
+    const idxByDate = {}
+    const cur = new Date(range.from)
+    const end = new Date(range.to)
+    while (cur <= end) {
+      const key = this.StudyGraphUtils.formatDate(cur)
+      idxByDate[key] = labels.length
+      labels.push(this.StudyGraphUtils.formatDate(new Date(key), "M/D"))
+      cur.setDate(cur.getDate() + 1)
     }
-
-    return this.createChart(canvasId, config)
-  },
-
-  // Book breakdown chart
-  createBookBreakdownChart(canvasId, days = 30) {
     const books = this.StudyGraphStore.state.books
-    const bookStats = books
-      .map((book) => ({
-        ...book,
-        stats: this.StudyGraphStore.getBookStats(book.id, days),
-      }))
-      .filter((book) => book.stats.minutes > 0)
-
+    const logs = this.StudyGraphStore.state.logs.filter(l => l.date in idxByDate)
+    const totalsByBook = new Map()
+    const dataByBook = new Map()
+    books.forEach(b => {
+      totalsByBook.set(b.id, 0)
+      dataByBook.set(b.id, new Array(labels.length).fill(0))
+    })
+    logs.forEach(l => {
+      const i = idxByDate[l.date]
+      const id = l.bookId
+      const m = l.minutes || 0
+      if (!dataByBook.has(id)) {
+        dataByBook.set(id, new Array(labels.length).fill(0))
+        totalsByBook.set(id, 0)
+      }
+      dataByBook.get(id)[i] += m
+      totalsByBook.set(id, (totalsByBook.get(id) || 0) + m)
+    })
+    const sorted = Array.from(totalsByBook.entries()).filter(([,t]) => t > 0).sort((a,b) => b[1]-a[1])
+    const top = sorted.slice(0, 12)
+    const others = sorted.slice(12)
+    const datasets = []
+    top.forEach(([bookId], i) => {
+      const book = books.find(b => b.id === bookId)
+      const color = this.palette[i % this.palette.length]
+      datasets.push({
+        label: book ? book.title : "教材",
+        data: dataByBook.get(bookId),
+        backgroundColor: color,
+        borderColor: color,
+        borderWidth: 1,
+        stack: "time"
+      })
+    })
+    if (others.length > 0) {
+      const sum = new Array(labels.length).fill(0)
+      others.forEach(([bookId]) => {
+        const arr = dataByBook.get(bookId) || []
+        for (let i = 0; i < sum.length; i++) sum[i] += arr[i] || 0
+      })
+      const color = "#94a3b8"
+      datasets.push({ label: "その他", data: sum, backgroundColor: color, borderColor: color, borderWidth: 1, stack: "time" })
+    }
     const config = {
       type: "bar",
-      data: {
-        labels: bookStats.map((book) => (book.title.length > 15 ? book.title.substring(0, 15) + "..." : book.title)),
-        datasets: [
-          {
-            label: "学習時間（分）",
-            data: bookStats.map((book) => book.stats.minutes),
-            backgroundColor: "rgba(106, 163, 255, 0.8)",
-            borderColor: "rgba(106, 163, 255, 1)",
-            borderWidth: 1,
-          },
-          {
-            label: "ページ数",
-            data: bookStats.map((book) => book.stats.pages),
-            backgroundColor: "rgba(139, 92, 246, 0.8)",
-            borderColor: "rgba(139, 92, 246, 1)",
-            borderWidth: 1,
-          },
-        ],
-      },
+      data: { labels, datasets },
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            position: "top",
-          },
-        },
         scales: {
-          y: {
-            beginAtZero: true,
-          },
-        },
-      },
+          x: { stacked: true },
+          y: { stacked: true, beginAtZero: true, ticks: { callback: v => v + "分" } }
+        }
+      }
     }
-
     return this.createChart(canvasId, config)
   },
 
-  // Subject pie chart
-  createSubjectPieChart(canvasId, days = 30) {
-    const subjectStats = this.StudyGraphStore.getSubjectStats(days)
-    const subjects = Object.keys(subjectStats)
-
-    const colors = [
-      "rgba(106, 163, 255, 0.8)",
-      "rgba(139, 92, 246, 0.8)",
-      "rgba(34, 197, 94, 0.8)",
-      "rgba(245, 158, 11, 0.8)",
-      "rgba(239, 68, 68, 0.8)",
-      "rgba(168, 85, 247, 0.8)",
-      "rgba(59, 130, 246, 0.8)",
-      "rgba(16, 185, 129, 0.8)",
-    ]
-
+  createBookBreakdownChart(canvasId, days) {
+    const books = this.StudyGraphStore.state.books
+    const stats = books.map(b => ({ book: b, stats: this.StudyGraphStore.getBookStats(b.id, days) })).filter(x => x.stats.minutes > 0)
+    const labels = stats.map(x => x.book.title.length > 15 ? x.book.title.substring(0, 15) + "..." : x.book.title)
+    const data = stats.map(x => x.stats.minutes)
+    const colors = labels.map((_, i) => this.palette[i % this.palette.length])
     const config = {
       type: "doughnut",
-      data: {
-        labels: subjects,
-        datasets: [
-          {
-            data: subjects.map((subject) => subjectStats[subject].minutes),
-            backgroundColor: colors.slice(0, subjects.length),
-            borderWidth: 2,
-            borderColor: "var(--bg)",
-          },
-        ],
-      },
+      data: { labels, datasets: [{ data, backgroundColor: colors, borderWidth: 0 }] },
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        cutout: "60%",
         plugins: {
-          legend: {
-            position: "bottom",
-          },
-        },
-      },
+          legend: { position: "right" },
+          centerText: { value: Math.round(data.reduce((a,b)=>a+b,0)) + "分", label: "時間配分", color: getComputedStyle(document.documentElement).color }
+        }
+      }
     }
-
     return this.createChart(canvasId, config)
   },
 
-  // Cumulative progress chart
-  createCumulativeChart(canvasId, days = 30) {
-    const dailyStats = this.StudyGraphStore.getDailyStats(days)
-
-    let cumulativePages = 0
-    let cumulativeQuestions = 0
-
-    const cumulativeData = dailyStats.map((stat) => {
-      cumulativePages += stat.pages
-      cumulativeQuestions += stat.questions
-      return {
-        date: stat.date,
-        pages: cumulativePages,
-        questions: cumulativeQuestions,
+  createSubjectPieChart(canvasId, days) {
+    const bySubj = this.StudyGraphStore.getSubjectStats(days)
+    const labels = Object.keys(bySubj)
+    const data = labels.map(k => bySubj[k].minutes)
+    const colors = labels.map((_, i) => this.palette[i % this.palette.length])
+    const config = {
+      type: "doughnut",
+      data: { labels, datasets: [{ data, backgroundColor: colors, borderWidth: 0 }] },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: "50%",
+        plugins: {
+          legend: { position: "right" }
+        }
       }
-    })
+    }
+    return this.createChart(canvasId, config)
+  },
 
+  createDailyRateChart(canvasId, days) {
+    const daily = this.StudyGraphStore.getDailyStats(days)
+    const labels = daily.map(s => this.StudyGraphUtils.formatDate(new Date(s.date), "M/D"))
+    const data = daily.map(s => s.achievementRate)
+    const config = {
+      type: "bar",
+      data: { labels, datasets: [{ label: "達成率", data, backgroundColor: "rgba(106,163,255,.8)", borderColor: "rgba(106,163,255,1)", borderWidth: 1 }] },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { beginAtZero: true, max: 150, ticks: { callback: v => v + "%" } }
+        }
+      }
+    }
+    return this.createChart(canvasId, config)
+  },
+
+  createCumulativeChart(canvasId, days) {
+    const daily = this.StudyGraphStore.getDailyStats(days)
+    let cp = 0, cq = 0
+    const labels = daily.map(s => this.StudyGraphUtils.formatDate(new Date(s.date), "M/D"))
+    const pages = daily.map(s => { cp += s.pages; return cp })
+    const questions = daily.map(s => { cq += s.questions; return cq })
     const config = {
       type: "line",
       data: {
-        labels: dailyStats.map((stat) => this.StudyGraphUtils.formatDate(new Date(stat.date), "MM/DD")),
+        labels,
         datasets: [
-          {
-            label: "累積ページ数",
-            data: cumulativeData.map((data) => data.pages),
-            borderColor: "rgba(106, 163, 255, 1)",
-            backgroundColor: "rgba(106, 163, 255, 0.1)",
-            fill: true,
-            tension: 0.4,
-          },
-          {
-            label: "累積問題数",
-            data: cumulativeData.map((data) => data.questions),
-            borderColor: "rgba(139, 92, 246, 1)",
-            backgroundColor: "rgba(139, 92, 246, 0.1)",
-            fill: true,
-            tension: 0.4,
-          },
-        ],
+          { label: "累積ページ数", data: pages, borderColor: "rgba(106,163,255,1)", backgroundColor: "rgba(106,163,255,.1)", fill: true, tension: .4 },
+          { label: "累積問題数", data: questions, borderColor: "rgba(139,92,246,1)", backgroundColor: "rgba(139,92,246,.1)", fill: true, tension: .4 }
+        ]
       },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            position: "top",
-          },
-        },
-        scales: {
-          y: {
-            beginAtZero: true,
-          },
-        },
-      },
+      options: { responsive: true, maintainAspectRatio: false }
     }
-
     return this.createChart(canvasId, config)
   },
 
-  // Create heatmap
+  createGoalDonutChart(canvasId, currentMinutes, targetMinutes) {
+    const v = Math.max(0, Math.min(100, targetMinutes > 0 ? Math.round(currentMinutes / targetMinutes * 100) : 0))
+    const config = {
+      type: "doughnut",
+      data: { labels: ["達成","残り"], datasets: [{ data: [v, 100 - v], backgroundColor: ["#6AA3FF","#E5E7EB"], borderWidth: 0 }] },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: "70%",
+        plugins: { legend: { display: false }, centerText: { value: v + " %", label: "今週の目標", color: getComputedStyle(document.documentElement).color } }
+      }
+    }
+    return this.createChart(canvasId, config)
+  },
+
   createHeatmap(containerId, year = new Date().getFullYear()) {
     const container = document.getElementById(containerId)
     if (!container) return
-
     container.innerHTML = ""
-
     if (this.StudyGraphStore.state.logs.length === 0) {
       const placeholder = document.createElement("div")
       placeholder.className = "chart-placeholder"
@@ -248,53 +255,34 @@ window.StudyGraphCharts = {
       container.appendChild(placeholder)
       return
     }
-
-    // Generate year data
     const startDate = new Date(year, 0, 1)
     const endDate = new Date(year, 11, 31)
     const days = []
-
     const current = new Date(startDate)
     while (current <= endDate) {
       const dateStr = this.StudyGraphUtils.formatDate(current)
-      const dayLogs = this.StudyGraphStore.state.logs.filter((log) => log.date === dateStr)
-      const minutes = dayLogs.reduce((sum, log) => sum + (log.minutes || 0), 0)
-
-      // Calculate level (0-4)
+      const dayLogs = this.StudyGraphStore.state.logs.filter(l => l.date === dateStr)
+      const minutes = dayLogs.reduce((sum, l) => sum + (l.minutes || 0), 0)
       let level = 0
       if (minutes > 0) {
-        if (minutes >= 240)
-          level = 4 // 4+ hours
-        else if (minutes >= 120)
-          level = 3 // 2+ hours
-        else if (minutes >= 60)
-          level = 2 // 1+ hour
-        else level = 1 // Any study
+        if (minutes >= 240) level = 4
+        else if (minutes >= 120) level = 3
+        else if (minutes >= 60) level = 2
+        else level = 1
       }
-
-      days.push({
-        date: dateStr,
-        minutes,
-        level,
-      })
-
+      days.push({ date: dateStr, minutes, level })
       current.setDate(current.getDate() + 1)
     }
-
-    // Render heatmap
-    days.forEach((day) => {
-      const dayElement = document.createElement("div")
-      dayElement.className = `heatmap-day heatmap-day--level-${day.level}`
-      dayElement.title = `${day.date}: ${this.StudyGraphUtils.formatDuration(day.minutes)}`
-      container.appendChild(dayElement)
+    days.forEach(day => {
+      const el = document.createElement("div")
+      el.className = `heatmap-day heatmap-day--level-${day.level}`
+      el.title = `${day.date}: ${this.StudyGraphUtils.formatDuration(day.minutes)}`
+      container.appendChild(el)
     })
   },
 
-  // Destroy all charts
   destroyAll() {
-    Object.values(this.charts).forEach((chart) => {
-      if (chart) chart.destroy()
-    })
+    Object.values(this.charts).forEach(c => { if (c) c.destroy() })
     this.charts = {}
-  },
+  }
 }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -10,6 +10,7 @@ window.StudyGraphStore = {
       firstDayOfWeek: 1,
       timeFormat: "HH:mm",
       displayUnit: "page-first",
+      weeklyTargetMinutes: 2400,
     },
     ui: {
       route: "#/dashboard",

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -57,8 +57,13 @@ window.StudyGraphUI = {
   },
 
   // Update dashboard chart
-  updateDashboardChart() {
-    window.StudyGraphCharts.createDailyRateChart("chart-daily-rate", 7)
+  updateDashboardChart(days = 7) {
+    window.StudyGraphCharts.createWeeklyStackedTimeChart("chart-daily-rate", 7)
+    window.StudyGraphCharts.createBookBreakdownChart("chart-book-breakdown", days)
+    window.StudyGraphCharts.createSubjectPieChart("chart-subject-pie", days)
+    window.StudyGraphCharts.createCumulativeChart("chart-cumulative", days)
+    const week = window.StudyGraphStore.getWeekStats()
+    window.StudyGraphCharts.createGoalDonutChart("chart-week-goal", week.minutes, window.StudyGraphStore.state.prefs.weeklyTargetMinutes || 2400)
   },
 
   // Initialize planner

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="assets/css/theme-dark.css" id="theme-stylesheet">
     
     <!-- Vendor Libraries -->
-    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script defer src="assets/vendor/chart.umd.min.js"></script>
     <script defer src="assets/vendor/idb-keyval-iife.min.js"></script>
     
     <!-- App Scripts -->
@@ -83,6 +83,20 @@
                                 </div>
                             </div>
                         </div>
+                        
+                        <div class="card card--kpi">
+                            <div class="kpi-card">
+                                <div class="kpi-card__header">
+                                    <h3>カウントダウン</h3>
+                                </div>
+                                <div class="kpi-card__content">
+                                    <div class="gauge-wrap">
+                                        <div id="countdown-days" style="font-size:48px;font-weight:700;line-height:1">0</div>
+                                        <div class="gauge-label">共通テストまで</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Quick Input -->
@@ -136,11 +150,22 @@
                     <!-- Weekly Chart -->
                     <div class="card card--chart">
                         <div class="card__header">
-                            <h2>7日間の達成率</h2>
+                            <h2>7日間の学習時間</h2>
                         </div>
                         <div class="card__content">
                             <div class="chart-container">
                                 <canvas id="chart-daily-rate"></canvas>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card card--chart">
+                        <div class="card__header">
+                            <h2>今週の目標</h2>
+                        </div>
+                        <div class="card__content">
+                            <div class="chart-container">
+                                <canvas id="chart-week-goal"></canvas>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- load Chart.js locally and expand dashboard with countdown and goal donut card
- replace chart utilities with fail-safe rendering, stacked weekly bars, and goal donut
- expose weekly target preference and countdown logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6b2ecca68832ca7c8b7322088815d